### PR TITLE
Take uvicorn server settings from `config.toml`

### DIFF
--- a/example-config.toml
+++ b/example-config.toml
@@ -1,4 +1,8 @@
 [uprn_mangle]
+api_base_url = "http://localhost"
+api_port = 8000
+api_prefix = "/api/v1"
+
 db_user = "addressbase"
 db_password = "mysecurepassword"
 db_name = "addressbase"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ ipykernel = "^6.29.4"
 # setup PoeThePoet tasks
 pre.cmd = "pre-commit run --all-files"
 pre.help = "Run pre-commit checks"
-mypy.cmd = "mypy --config-file pyproject.toml uprn_mangle/**/*.py tests/**/*.py --strict"
+mypy.cmd = "mypy --config-file pyproject.toml uprn_mangle/backend/**/*.py tests/**/*.py --strict"
 mypy.help = "Run mypy checks"
 format.cmd = "ruff format ."
 format.help = "Format code with Ruff"
@@ -184,6 +184,7 @@ keep-runtime-typing = true
 plugins = ["pydantic.mypy"]
 disallow_untyped_defs = true
 python_version = "3.10"
+exclude = ["uprn_mangle/frontend"]
 
 [[tool.mypy.overrides]]
 disable_error_code = ["method-assign", "no-untyped-def", "attr-defined"]

--- a/uprn_mangle/backend/api/main.py
+++ b/uprn_mangle/backend/api/main.py
@@ -3,13 +3,17 @@
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from typing import Any
+from urllib.parse import urlparse
 
 import uvicorn
 from fastapi import FastAPI
 from fastapi_pagination import add_pagination
 
 from uprn_mangle.backend.api.routes import router
+from uprn_mangle.backend.config import get_settings
 from uprn_mangle.backend.database import init_models
+
+settings = get_settings()
 
 
 @asynccontextmanager
@@ -19,10 +23,19 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[Any, None]:  # noqa: ARG001
     yield
 
 
-app = FastAPI(lifespan=lifespan)
-app.include_router(router, prefix="/api/v2")
+app = FastAPI(
+    lifespan=lifespan,
+    swagger_ui_parameters={"defaultModelsExpandDepth": 0},
+)
+app.include_router(router, prefix=settings.api_prefix)
 
 add_pagination(app)
 
 if __name__ == "__main__":
-    uvicorn.run("uprn_mangle.backend.api.main:app", reload=True)
+    host = urlparse(settings.api_base_url).hostname
+    uvicorn.run(
+        "uprn_mangle.backend.api.main:app",
+        reload=True,
+        port=settings.api_port,
+        host=host,
+    )

--- a/uprn_mangle/backend/api/main.py
+++ b/uprn_mangle/backend/api/main.py
@@ -33,6 +33,9 @@ add_pagination(app)
 
 if __name__ == "__main__":
     host = urlparse(settings.api_base_url).hostname
+    if not host:
+        msg = "Bad api_base_url setting, please check the config.toml file."
+        raise SystemExit(msg)
     uvicorn.run(
         "uprn_mangle.backend.api.main:app",
         reload=True,

--- a/uprn_mangle/backend/config/settings.py
+++ b/uprn_mangle/backend/config/settings.py
@@ -17,6 +17,20 @@ class Settings(TOMLSettings):
     db_port: str = "5432"
     db_table: str = "addressbase"
 
+    api_base_url: str = ""
+    api_port: int = 8000
+    api_prefix: str = ""
+
+    def __post_init__(self) -> None:
+        """Make sure that the api_base_url is not blank."""
+        super().__post_init__()
+        if not self.api_base_url:
+            rprint(
+                "\n[red] -> The api_base_url setting is blank, please set it "
+                "in the '[b]config.toml[/b]' file and try again.\n"
+            )
+            raise SystemExit
+
 
 def get_settings() -> Settings:
     """Get the settings."""


### PR DESCRIPTION
Take the `api_base_url`, `api_port` and `api_prefix` from the `config.toml` file instead of hard-coding.

Also add logic to ensure the `api_base_url` is not blank